### PR TITLE
Fixes a Crash when loading Projects  (Overflow) and Adds Support for Projects with subdirectories 

### DIFF
--- a/QCStudioPlugin/Forms/OpenProjects.cs
+++ b/QCStudioPlugin/Forms/OpenProjects.cs
@@ -117,7 +117,7 @@ namespace QuantConnect.QCPlugin
                 return;
             }
 
-            selectedProject = Convert.ToInt16(listViewProjects.SelectedItems[0].Text);
+            selectedProject = Convert.ToInt32(listViewProjects.SelectedItems[0].Text);
             projectName = listViewProjects.FocusedItem.SubItems[1].Text;
 
             buttonOpen.Enabled = false;

--- a/QCStudioPlugin/QuantConnectPlugin/QuantConnectPlugin.cs
+++ b/QCStudioPlugin/QuantConnectPlugin/QuantConnectPlugin.cs
@@ -504,6 +504,7 @@ namespace QuantConnect.QCPlugin
         }
 
         /// <summary>
+        /// Worker function for adding subdirectories to the file list for saving projects to the cloud.
         /// </summary>
         /// <param name="basePath"></param>
         /// <param name="dirPath"></param>


### PR DESCRIPTION
Two real changes: 
* Crash when loading Projects:
   ProjectIDs no longer fit in a signed Int16, so loading new projects was causing an OverFlowException
* Adds Support for Opening/Saving Projects with code in subdirectories
   Tested using: QCU Strategy Example: Complete Algorithm Framework

Also contains a small cleanup reducing the duplication of building Project Paths, by creating a utility function for this purpose.